### PR TITLE
Add Finnish Nature Day: last Saturday of August 2017

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,6 +229,8 @@
         // One-offs
         if (dd === 4 && mm === SEPTEMBER && yyyy === 2014) {
             reason = "70 years since the end of the Continuation War";
+        } else if if (dd === 26 && mm === AUGUST && yyyy === 2017) {
+            reason = "Finnish Nature Day";
         }
         // Format like 4th June 2014
         var m_names = ["January", "February", "March",


### PR DESCRIPTION
So far just a one-off.

> In 2017, when Finland celebrates its centenary of independence, Finland will become the first country in the world to honour its natural environment with an official flag day. The Ministry of the Interior has ordered that flags should be flown on Finnish Nature Day, which falls on the last Saturday of August. Next year, this will be 26 August 2017. This will round off the celebration of Nature Days – hundreds of nature events, either organised or pop-up – in honour of the 100th anniversary of Finland’s independence.
>
> “According to our survey, nine out of ten Finns want to celebrate Finnish nature as part of Finland’s centennial jubilee in 2017,” says Pekka Timonen, General Secretary of the Finland 100 organisation. “This is an excellent reason for introducing a new flag day.”
>
> Nature Days wants to bring people together and draw them out into Finland’s natural settings in celebration of Finns’ relationship with nature and its continuity.
> 
> “The strong presence of nature in Finland’s centenary year celebrations has attracted wide international interest,” Timonen continues. “Nature related programmes played a key role when the major international travel media publications, Lonely Planet and National Geographic, ranked Finland as one of the best destinations for 2017.”
>
> In honour of Finland’s 100 years of independence, Finnish Nature Day has been expanded into four Nature Days, supported by around 50 organisations. The aim of the Nature Days campaign is to have Finnish flags flown on as many poles as possible, with small flags displayed in various connections, such as on nature trails, to decorate hiking food, or in other ways. The flag theme will also feature in social media posts for Nature Days. The ultimate goal is to make Finnish Nature Day, i.e. the last Saturday of August, an established flag day.

http://suomifinland100.fi/news/finland-to-become-the-worlds-first-country-to-fly-a-flag-for-nature/?lang=en