### PR TITLE
Move date calculation and reasoning into own JS file

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,14 +125,12 @@ function getURLParameter(name) {
     why = why_are_the_flags_up(date);
     var reason = why[0];
     var other_reason = why[1];
-    var date_format = why[2];
-    var intro = why[3];
-    var enable_background_image = why[4];
+    var intro = why[2];
+    var enable_background_image = why[3];
 
     $('#intro').html(intro);
     $('#reason').html(reason);
     $('#other_reason').html(other_reason);
-    $('#date').html(date_format);
     if (enable_background_image) {
         var htmlElement = document.querySelector("html");
         htmlElement.style.backgroundImage = 'url(images/flag.jpg)';

--- a/index.html
+++ b/index.html
@@ -114,7 +114,6 @@ function getURLParameter(name) {
 }
 
     var today = new Date();
-    today.setHours(0, 0, 0, 0); // keep date, ditch time
     dateParam = getURLParameter('date');
     if (dateParam !== 'null') {
         dateParam = dateParam.replace(/\+/g, '-'); // Replace all + with -

--- a/index.html
+++ b/index.html
@@ -123,15 +123,15 @@ function getURLParameter(name) {
     }
 
     why = why_are_the_flags_up(date);
-    var reason = why[0];
-    var other_reason = why[1];
-    var intro = why[2];
-    var enable_background_image = why[3];
+    var flags_up = why[0];
+    var reason = why[1];
+    var other_reason = why[2];
+    var intro = why[3];
 
     $('#intro').html(intro);
     $('#reason').html(reason);
     $('#other_reason').html(other_reason);
-    if (enable_background_image) {
+    if (flags_up) {
         var htmlElement = document.querySelector("html");
         htmlElement.style.backgroundImage = 'url(images/flag.jpg)';
         $("#reason").addClass("outline");

--- a/index.html
+++ b/index.html
@@ -113,20 +113,20 @@ function getURLParameter(name) {
     );
 }
 
-    var today = new Date();
     dateParam = getURLParameter('date');
+    var date;
     if (dateParam !== 'null') {
         dateParam = dateParam.replace(/\+/g, '-'); // Replace all + with -
-        var date = new Date(dateParam);
+        date = new Date(dateParam);
     } else {
-        var date = today;
+        date = new Date(); // Today
     }
 
     why = why_are_the_flags_up(date);
-    var flags_up = why[0];
-    var reason = why[1];
-    var other_reason = why[2];
-    var intro = why[3];
+    const flags_up = why[0];
+    const reason = why[1];
+    const other_reason = why[2];
+    const intro = why[3];
 
     $('#intro').html(intro);
     $('#reason').html(reason);

--- a/index.html
+++ b/index.html
@@ -101,190 +101,35 @@
 
     <script src='jquery-1.11.2.min.js'></script>
     <script src="jquery.textfill.min.js"></script>
+    <script src="whyaretheflagsup.js"></script>
 
     <script type="text/javascript">
         <!--
-        var SUNDAY = 0;
-        var MONDAY = 1;
-        var TUESDAY = 2;
-        var WEDNESDAY = 3;
-        var THURSDAY = 4;
-        var FRIDAY = 5;
-        var SATURDAY = 6;
-
-        var JANUARY = 1;
-        var FEBRUARY = 2;
-        var MARCH = 3;
-        var APRIL = 4;
-        var MAY = 5;
-        var JUNE = 6;
-        var JULY = 7;
-        var AUGUST = 8;
-        var SEPTEMBER = 9;
-        var OCTOBER = 10;
-        var NOVEMBER = 11;
-        var DECEMBER = 12;
-
-        function getURLParameter(name) {
-            return decodeURI(
-                (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,null])[1]
-            );
-        }
-
-        function is_xth_day_in_month(date, required_xth, required_day, required_mm) {
-            // Is this the required_xth required_day in required_mm?
-            // For example, is this the second Sunday in May?
-            var day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6
-            var dd = date.getDate();
-            var mm = date.getMonth() + 1; // January is 0!
-
-            var max_dd = required_xth * 7;
-            var min_dd = max_dd - 6;
-
-            if (mm === required_mm && dd >= min_dd && dd <= max_dd && day === required_day) {
-                return true;
-            }
-            return false;
-        }
-
-        var today = new Date();
-        var past = false;
-        var future = false;
-        var intro = 'Flags are up in Finland because today, <span id="date" class="date"></span>, is:';
-        today.setHours(0, 0, 0, 0); // keep date, ditch time
-        dateParam = getURLParameter('date');
-        if (dateParam !== 'null') {
-            dateParam = dateParam.replace(/\+/g, '-'); // Replace all + with -
-            var date = new Date(dateParam);
-            if (date < today) {
-                past = true;
-                intro = 'Flags were up in Finland because <span id="date" class="date"></span> was:';
-            } else if (today < date) {
-                future = true;
-                intro = 'Flags will be up in Finland because <span id="date" class="date"></span> will be:';
-            }
-        } else {
-            var date = today;
-        }
-        var day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6
-        var dd = date.getDate();
-        var mm = date.getMonth() + 1; // January is 0!
-        var yyyy = date.getFullYear();
-        var reason = "";
-        var other_reason = "";
-        var enable_background_image = true;
-
-        // Static dates
-        if (mm === FEBRUARY && dd === 5) {
-            reason = 'Birthday of the national poet Johan Ludvig Runeberg';
-        } else if (mm === FEBRUARY && dd === 28) {
-            reason = 'Day of Kalevala; the occasion is also celebrated as the Day of Finnish culture';
-        } else if (mm === MARCH && dd === 19) {
-            reason = 'Birthday of novelist and playwright Minna Canth, Day of Equality';
-        } else if (mm === APRIL && dd === 9) {
-            reason = 'The day Mikael Agricola, the founder of the literary Finnish died and Elias Lönnrot, a collector of folklore was born; the occasion is also celebrated as the Day of the Finnish language';
-        } else if (mm === APRIL && dd === 27) {
-            reason = "National War Veterans' Day";
-        } else if (mm === MAY && dd === 1) {
-            reason = 'Vappu, the Day of Finnish Labour';
-        } else if (mm === MAY && dd === 9) {
-            reason = 'Europe Day';
-        } else if (mm === MAY && dd === 12) {
-            reason = 'Day of the Finnish Identity, birthday of the statesman Johan Vilhelm Snellman';
-        } else if (mm === JUNE && dd === 4) {
-            reason = 'Birthday of Carl Gustaf Emil Mannerheim, Marshal of Finland; the occasion is also celebrated as the Flag Day of the Finnish Defence Forces';
-        } else if (mm === JULY && dd === 6) {
-            reason = 'Birthday of the poet Eino Leino; the occasion is also a celebration of poetry and summer';
-        } else if (mm === JULY && dd === 10 && yyyy >= 2017) {
-            reason = "Helene Schjerfbeck Day, anniversary of the birth of the celebrated Finnish painter Helene Schjerfbeck; Finnish Visual Arts Day";
-        } else if (mm === OCTOBER && dd === 1 && yyyy >= 2017) {
-            reason = 'To honour Miina Sillanpää and civic influence';
-        } else if (mm === OCTOBER && dd === 10) {
-            reason = 'Birthday of the National writer Aleksis Kivi; the occasion is also celebrated as the Day of Finnish literature';
-        } else if (mm === OCTOBER && dd === 24) {
-            reason = 'Day of the United Nations';
-        } else if (mm === NOVEMBER && dd === 6) {
-            reason = 'Day of the Swedish Identity and Gustavus Adolphus Day';
-        } else if (mm === NOVEMBER && dd === 20) {
-            reason = "Universal Children's Day";
-        } else if (mm === DECEMBER && dd === 6) {
-            reason = 'Independence Day';
-        } else if (mm === DECEMBER && dd === 8) {
-            reason = 'Birthday of the composer Jean Sibelius; the occasion is also celebrated as the Day of Finnish music';
-        }
-
-        // Moveable dates
-        if (is_xth_day_in_month(date, 2, SUNDAY, MAY)) {
-            reason = "Mother's Day";
-        } else if (is_xth_day_in_month(date, 3, SUNDAY, MAY)) {
-            reason = "Memorial day for the war dead (everyone who has died in Finnish wars, combat-like duties or peacekeeping operations both during fighting and after they've ceased, including those executed or who have died as a POW)";
-        } else if (mm === JUNE && dd >= 19 && dd <= 25 && day === FRIDAY) {
-            reason = "Midsummer's eve";
-        } else if (mm === JUNE && dd >= 20 && dd <= 26 && day === SATURDAY) {
-            reason = "Midsummer";
-        } else if (mm === AUGUST && dd >= 25 && dd <= 31 && day === SATURDAY && yyyy >= 2017) {
-            reason = "Finnish Nature Day";
-        } else if (is_xth_day_in_month(date, 2, SUNDAY, NOVEMBER)) {
-            reason = "Father's Day";
-        }
-
-        // General election every fourth year. Since 2011: third Sunday in April.
-        if (is_xth_day_in_month(date, 3, SUNDAY, APRIL)) {
-            if ((yyyy - 2011) % 4 === 0) {
-            reason = "A parliamentary election";
-            }
-        }
-
-        // Other elections
-        if (dd === 28 && mm === JANUARY && yyyy === 2018) {
-            reason = "A presidential election";
-        }
-        // One-offs
-        if (dd === 4 && mm === SEPTEMBER && yyyy === 2014) {
-            reason = "70 years since the end of the Continuation War";
-        } else if (dd === 5 && mm === DECEMBER && yyyy === 2017) {
-            reason = "Finland's Centenary Independence Day Eve";
-        } else if (dd === 1 && mm === FEBRUARY && yyyy === 2018) {
-            reason = "Inauguration of the President";
-        } else if (dd === 28 && mm === MAY && yyyy === 2018) {
-            reason = "100th anniversary of the Finnish flag";
-        } else if (dd === 16 && mm === FEBRUARY && yyyy === 2018) {
-            reason = "Lithuania's 100 years of independence";
-        } else if (dd === 24 && mm === FEBRUARY && yyyy === 2018) {
-            reason = "Estonia's 100 years of independence";
-        } else if (dd === 18 && mm === NOVEMBER && yyyy === 2018) {
-            reason = "Latvia's 100 years of independence";
-        }
-
-        // Format like 4th June 2014
-        var m_names = ["January", "February", "March",
-                "April", "May", "June", "July", "August", "September",
-                "October", "November", "December"];
-        var suffix = "";
-        if (dd === 1 || dd === 21 || dd === 31) {
-            suffix = "st";
-        } else if (dd === 2 || dd === 22) {
-            suffix = "nd";
-        } else if (dd === 3 || dd === 23) {
-            suffix = "rd";
-        } else {
-            suffix = "th";
-        }
-        var date_format = dd + "" + suffix + " " + m_names[mm - 1] + " " + yyyy;
-        if (reason === "") {
-            intro = '';
-            if (past) {
-                reason = 'Flags were not up in Finland on <span id="date" class="date"></span>';
-            } else if (future) {
-                reason = 'Flags will not be up in Finland on <span id="date" class="date"></span>';
-            } else {
-                reason = 'Flags are not up in Finland today, <span id="date" class="date"></span>';
-            }
-            other_reason = "(Unless there's elections, a referendum, the president is inaugurated, or something else &ndash; <a href=\"https://github.com/whyaretheflagsup/whyaretheflagsup/issues/new\">let us know</a>)";
-            enable_background_image = false;
-        }
-
 $(document).ready(function() {
+
+function getURLParameter(name) {
+    return decodeURI(
+        (RegExp(name + '=' + '(.+?)(&|$)').exec(location.search)||[,null])[1]
+    );
+}
+
+    var today = new Date();
+    today.setHours(0, 0, 0, 0); // keep date, ditch time
+    dateParam = getURLParameter('date');
+    if (dateParam !== 'null') {
+        dateParam = dateParam.replace(/\+/g, '-'); // Replace all + with -
+        var date = new Date(dateParam);
+    } else {
+        var date = today;
+    }
+
+    why = why_are_the_flags_up(date);
+    var reason = why[0];
+    var other_reason = why[1];
+    var date_format = why[2];
+    var intro = why[3];
+    var enable_background_image = why[4];
+
     $('#intro').html(intro);
     $('#reason').html(reason);
     $('#other_reason').html(other_reason);

--- a/whyaretheflagsup.js
+++ b/whyaretheflagsup.js
@@ -1,0 +1,180 @@
+const SUNDAY = 0;
+const MONDAY = 1;
+const TUESDAY = 2;
+const WEDNESDAY = 3;
+const THURSDAY = 4;
+const FRIDAY = 5;
+const SATURDAY = 6;
+
+const JANUARY = 1;
+const FEBRUARY = 2;
+const MARCH = 3;
+const APRIL = 4;
+const MAY = 5;
+const JUNE = 6;
+const JULY = 7;
+const AUGUST = 8;
+const SEPTEMBER = 9;
+const OCTOBER = 10;
+const NOVEMBER = 11;
+const DECEMBER = 12;
+
+function is_xth_day_in_month(date, required_xth, required_day, required_mm) {
+    // Is this the required_xth required_day in required_mm?
+    // For example, is this the second Sunday in May?
+    var day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6
+    var dd = date.getDate();
+    var mm = date.getMonth() + 1; // January is 0!
+
+    var max_dd = required_xth * 7;
+    var min_dd = max_dd - 6;
+
+    if (mm === required_mm && dd >= min_dd && dd <= max_dd && day === required_day) {
+        return true;
+    }
+    return false;
+}
+
+function why_are_the_flags_up(date) {
+    var today = new Date();
+    today.setHours(0, 0, 0, 0); // keep date, ditch time
+    var past = false;
+    var future = false;
+    var day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6
+    var dd = date.getDate();
+    var mm = date.getMonth() + 1; // January is 0!
+    var yyyy = date.getFullYear();
+    var reason = "";
+    var other_reason = "";
+    var enable_background_image = true;
+    
+    if (date < today) {
+        past = true;
+        intro = 'Flags were up in Finland because <span id="date" class="date"></span> was:';
+    } else if (today < date) {
+        future = true;
+        intro = 'Flags will be up in Finland because <span id="date" class="date"></span> will be:';
+    }
+
+    // Static dates
+    if (mm === FEBRUARY && dd === 5) {
+        reason = 'Birthday of the national poet Johan Ludvig Runeberg';
+    } else if (mm === FEBRUARY && dd === 28) {
+        reason = 'Day of Kalevala; the occasion is also celebrated as the Day of Finnish culture';
+    } else if (mm === MARCH && dd === 19) {
+        reason = 'Birthday of novelist and playwright Minna Canth, Day of Equality';
+    } else if (mm === APRIL && dd === 9) {
+        reason = 'The day Mikael Agricola, the founder of the literary Finnish died and Elias Lönnrot, a collector of folklore was born; the occasion is also celebrated as the Day of the Finnish language';
+    } else if (mm === APRIL && dd === 27) {
+        reason = "National War Veterans' Day";
+    } else if (mm === MAY && dd === 1) {
+        reason = 'Vappu, the Day of Finnish Labour';
+    } else if (mm === MAY && dd === 9) {
+        reason = 'Europe Day';
+    } else if (mm === MAY && dd === 12) {
+        reason = 'Day of the Finnish Identity, birthday of the statesman Johan Vilhelm Snellman';
+    } else if (mm === JUNE && dd === 4) {
+        reason = 'Birthday of Carl Gustaf Emil Mannerheim, Marshal of Finland; the occasion is also celebrated as the Flag Day of the Finnish Defence Forces';
+    } else if (mm === JULY && dd === 6) {
+        reason = 'Birthday of the poet Eino Leino; the occasion is also a celebration of poetry and summer';
+    } else if (mm === JULY && dd === 10 && yyyy >= 2017) {
+        reason = "Helene Schjerfbeck Day, anniversary of the birth of the celebrated Finnish painter Helene Schjerfbeck; Finnish Visual Arts Day";
+    } else if (mm === OCTOBER && dd === 1 && yyyy >= 2017) {
+        reason = 'To honour Miina Sillanpää and civic influence';
+    } else if (mm === OCTOBER && dd === 10) {
+        reason = 'Birthday of the National writer Aleksis Kivi; the occasion is also celebrated as the Day of Finnish literature';
+    } else if (mm === OCTOBER && dd === 24) {
+        reason = 'Day of the United Nations';
+    } else if (mm === NOVEMBER && dd === 6) {
+        reason = 'Day of the Swedish Identity and Gustavus Adolphus Day';
+    } else if (mm === NOVEMBER && dd === 20) {
+        reason = "Universal Children's Day";
+    } else if (mm === DECEMBER && dd === 6) {
+        reason = 'Independence Day';
+    } else if (mm === DECEMBER && dd === 8) {
+        reason = 'Birthday of the composer Jean Sibelius; the occasion is also celebrated as the Day of Finnish music';
+    }
+    
+    // Moveable dates
+    if (is_xth_day_in_month(date, 2, SUNDAY, MAY)) {
+        reason = "Mother's Day";
+    } else if (is_xth_day_in_month(date, 3, SUNDAY, MAY)) {
+        reason = "Memorial day for the war dead (everyone who has died in Finnish wars, combat-like duties or peacekeeping operations both during fighting and after they've ceased, including those executed or who have died as a POW)";
+    } else if (mm === JUNE && dd >= 19 && dd <= 25 && day === FRIDAY) {
+        reason = "Midsummer's eve";
+    } else if (mm === JUNE && dd >= 20 && dd <= 26 && day === SATURDAY) {
+        reason = "Midsummer";
+    } else if (mm === AUGUST && dd >= 25 && dd <= 31 && day === SATURDAY && yyyy >= 2017) {
+        reason = "Finnish Nature Day";
+    } else if (is_xth_day_in_month(date, 2, SUNDAY, NOVEMBER)) {
+        reason = "Father's Day";
+    }
+    
+    // General election every fourth year. Since 2011: third Sunday in April.
+    if (is_xth_day_in_month(date, 3, SUNDAY, APRIL)) {
+        if ((yyyy - 2011) % 4 === 0) {
+        reason = "A parliamentary election";
+        }
+    }
+    
+    // Other elections
+    if (dd === 28 && mm === JANUARY && yyyy === 2018) {
+        reason = "A presidential election";
+    }
+    // One-offs
+    if (dd === 4 && mm === SEPTEMBER && yyyy === 2014) {
+        reason = "70 years since the end of the Continuation War";
+    } else if (dd === 5 && mm === DECEMBER && yyyy === 2017) {
+        reason = "Finland's Centenary Independence Day Eve";
+    } else if (dd === 1 && mm === FEBRUARY && yyyy === 2018) {
+        reason = "Inauguration of the President";
+    } else if (dd === 28 && mm === MAY && yyyy === 2018) {
+        reason = "100th anniversary of the Finnish flag";
+    } else if (dd === 16 && mm === FEBRUARY && yyyy === 2018) {
+        reason = "Lithuania's 100 years of independence";
+    } else if (dd === 24 && mm === FEBRUARY && yyyy === 2018) {
+        reason = "Estonia's 100 years of independence";
+    } else if (dd === 18 && mm === NOVEMBER && yyyy === 2018) {
+        reason = "Latvia's 100 years of independence";
+    }
+    
+    // Format like 4th June 2014
+    var m_names = ["January", "February", "March",
+            "April", "May", "June", "July", "August", "September",
+            "October", "November", "December"];
+    var suffix = "";
+    if (dd === 1 || dd === 21 || dd === 31) {
+        suffix = "st";
+    } else if (dd === 2 || dd === 22) {
+        suffix = "nd";
+    } else if (dd === 3 || dd === 23) {
+        suffix = "rd";
+    } else {
+        suffix = "th";
+    }
+    var date_format = dd + "" + suffix + " " + m_names[mm - 1] + " " + yyyy;
+    if (reason === "") {
+        intro = '';
+        if (past) {
+            reason = 'Flags were not up in Finland on <span id="date" class="date"></span>';
+        } else if (future) {
+            reason = 'Flags will not be up in Finland on <span id="date" class="date"></span>';
+        } else {
+            reason = 'Flags are not up in Finland today, <span id="date" class="date"></span>';
+        }
+        other_reason = "(Unless there's elections, a referendum, the president is inaugurated, or something else &ndash; <a href=\"https://github.com/whyaretheflagsup/whyaretheflagsup/issues/new\">let us know</a>)";
+        enable_background_image = false;
+    }
+
+    return [
+        reason,
+        other_reason,
+        date_format,
+        intro,
+        enable_background_image,
+    ]
+
+
+}
+
+

--- a/whyaretheflagsup.js
+++ b/whyaretheflagsup.js
@@ -47,8 +47,8 @@ function why_are_the_flags_up(date) {
     var yyyy = date.getFullYear();
     var reason = "";
     var other_reason = "";
-    var enable_background_image = true;
-
+    var flags_up = true;
+    
     // Format like 4th June 2014
     var m_names = ["January", "February", "March",
             "April", "May", "June", "July", "August", "September",
@@ -156,6 +156,7 @@ function why_are_the_flags_up(date) {
     }
     
     if (reason === "") {
+        flags_up = false;
         intro = '';
         if (past) {
             reason = 'Flags were not up in Finland on ' + date_format;
@@ -165,14 +166,13 @@ function why_are_the_flags_up(date) {
             reason = 'Flags are not up in Finland today, ' + date_format;
         }
         other_reason = "(Unless there's elections, a referendum, the president is inaugurated, or something else &ndash; <a href=\"https://github.com/whyaretheflagsup/whyaretheflagsup/issues/new\">let us know</a>)";
-        enable_background_image = false;
     }
 
     return [
+        flags_up,
         reason,
         other_reason,
         intro,
-        enable_background_image,
     ]
 
 

--- a/whyaretheflagsup.js
+++ b/whyaretheflagsup.js
@@ -38,6 +38,7 @@ function is_xth_day_in_month(date, required_xth, required_day, required_mm) {
 function why_are_the_flags_up(date) {
     var today = new Date();
     today.setHours(0, 0, 0, 0); // keep date, ditch time
+    date.setHours(0, 0, 0, 0); // keep date, ditch time
     var past = false;
     var future = false;
     var day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6

--- a/whyaretheflagsup.js
+++ b/whyaretheflagsup.js
@@ -48,13 +48,29 @@ function why_are_the_flags_up(date) {
     var reason = "";
     var other_reason = "";
     var enable_background_image = true;
-    
+
+    // Format like 4th June 2014
+    var m_names = ["January", "February", "March",
+            "April", "May", "June", "July", "August", "September",
+            "October", "November", "December"];
+    var suffix = "";
+    if (dd === 1 || dd === 21 || dd === 31) {
+        suffix = "st";
+    } else if (dd === 2 || dd === 22) {
+        suffix = "nd";
+    } else if (dd === 3 || dd === 23) {
+        suffix = "rd";
+    } else {
+        suffix = "th";
+    }
+    var date_format = dd + "" + suffix + " " + m_names[mm - 1] + " " + yyyy;
+
     if (date < today) {
         past = true;
-        intro = 'Flags were up in Finland because <span id="date" class="date"></span> was:';
+        intro = 'Flags were up in Finland because ' + date_format + ' was:';
     } else if (today < date) {
         future = true;
-        intro = 'Flags will be up in Finland because <span id="date" class="date"></span> will be:';
+        intro = 'Flags will be up in Finland because ' + date_format + ' will be:';
     }
 
     // Static dates
@@ -139,29 +155,14 @@ function why_are_the_flags_up(date) {
         reason = "Latvia's 100 years of independence";
     }
     
-    // Format like 4th June 2014
-    var m_names = ["January", "February", "March",
-            "April", "May", "June", "July", "August", "September",
-            "October", "November", "December"];
-    var suffix = "";
-    if (dd === 1 || dd === 21 || dd === 31) {
-        suffix = "st";
-    } else if (dd === 2 || dd === 22) {
-        suffix = "nd";
-    } else if (dd === 3 || dd === 23) {
-        suffix = "rd";
-    } else {
-        suffix = "th";
-    }
-    var date_format = dd + "" + suffix + " " + m_names[mm - 1] + " " + yyyy;
     if (reason === "") {
         intro = '';
         if (past) {
-            reason = 'Flags were not up in Finland on <span id="date" class="date"></span>';
+            reason = 'Flags were not up in Finland on ' + date_format;
         } else if (future) {
-            reason = 'Flags will not be up in Finland on <span id="date" class="date"></span>';
+            reason = 'Flags will not be up in Finland on ' + date_format;
         } else {
-            reason = 'Flags are not up in Finland today, <span id="date" class="date"></span>';
+            reason = 'Flags are not up in Finland today, ' + date_format;
         }
         other_reason = "(Unless there's elections, a referendum, the president is inaugurated, or something else &ndash; <a href=\"https://github.com/whyaretheflagsup/whyaretheflagsup/issues/new\">let us know</a>)";
         enable_background_image = false;
@@ -170,7 +171,6 @@ function why_are_the_flags_up(date) {
     return [
         reason,
         other_reason,
-        date_format,
         intro,
         enable_background_image,
     ]

--- a/whyaretheflagsup.js
+++ b/whyaretheflagsup.js
@@ -22,12 +22,12 @@ const DECEMBER = 12;
 function is_xth_day_in_month(date, required_xth, required_day, required_mm) {
     // Is this the required_xth required_day in required_mm?
     // For example, is this the second Sunday in May?
-    var day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6
-    var dd = date.getDate();
-    var mm = date.getMonth() + 1; // January is 0!
+    const day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6
+    const dd = date.getDate();
+    const mm = date.getMonth() + 1; // January is 0!
 
-    var max_dd = required_xth * 7;
-    var min_dd = max_dd - 6;
+    const max_dd = required_xth * 7;
+    const min_dd = max_dd - 6;
 
     if (mm === required_mm && dd >= min_dd && dd <= max_dd && day === required_day) {
         return true;
@@ -39,18 +39,18 @@ function why_are_the_flags_up(date) {
     var today = new Date();
     today.setHours(0, 0, 0, 0); // keep date, ditch time
     date.setHours(0, 0, 0, 0); // keep date, ditch time
+    const day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6
+    const dd = date.getDate();
+    const mm = date.getMonth() + 1; // January is 0!
+    const yyyy = date.getFullYear();
     var past = false;
     var future = false;
-    var day = date.getDay(); // Sunday is 0, Monday is 1, ... Saturday is 6
-    var dd = date.getDate();
-    var mm = date.getMonth() + 1; // January is 0!
-    var yyyy = date.getFullYear();
     var reason = "";
     var other_reason = "";
     var flags_up = true;
     
     // Format like 4th June 2014
-    var m_names = ["January", "February", "March",
+    const m_names = ["January", "February", "March",
             "April", "May", "June", "July", "August", "September",
             "October", "November", "December"];
     var suffix = "";
@@ -63,7 +63,7 @@ function why_are_the_flags_up(date) {
     } else {
         suffix = "th";
     }
-    var date_format = dd + "" + suffix + " " + m_names[mm - 1] + " " + yyyy;
+    const date_format = dd + "" + suffix + " " + m_names[mm - 1] + " " + yyyy;
 
     if (date < today) {
         past = true;


### PR DESCRIPTION
So it may be reused.

Example usage:

```html
<script src="whyaretheflagsup.js"></script>
```
```js
var today = new Date();

why = why_are_the_flags_up(today);

var flags_up = why[0];
var reason = why[1];
var other_reason = why[2];
var intro = why[3];
```
