### PR TITLE
Add flag day for Tove Jansson and Finnish art

### DIFF
--- a/whyaretheflagsup.js
+++ b/whyaretheflagsup.js
@@ -98,6 +98,8 @@ function why_are_the_flags_up(date) {
         reason = 'Birthday of the poet Eino Leino; the occasion is also a celebration of poetry and summer';
     } else if (mm === JULY && dd === 10 && yyyy >= 2017) {
         reason = "Helene Schjerfbeck Day, anniversary of the birth of the celebrated Finnish painter Helene Schjerfbeck; Finnish Visual Arts Day";
+    } else if (mm === AUGUST && dd === 9 && yyyy >= 2020) {
+        reason = "To celebrate Tove Jansson and Finnish art";
     } else if (mm === OCTOBER && dd === 1 && yyyy >= 2017) {
         reason = 'To honour Miina Sillanpää and civic influence';
     } else if (mm === OCTOBER && dd === 10) {


### PR DESCRIPTION
> # Flags to be flown for Tove Jansson and Finnish art on Sunday 9 August
>
> The Ministry of the Interior recommends that the national flag be flown throughout the country on Sunday 9 August 2020 to celebrate Tove Jansson and Finnish art. Flags are to be raised at 8.00 and lowered at 21.00.
>
> Tove Jansson is an influential artist and writer and is internationally renowned for her works. Her novels and other written work have been translated into more than 50 languages. Although Jansson is best known for her Moomin books, she was also a distinguished painter and illustrator. Many of her works deal with themes related to the status of minorities and the experiences and acceptance of diversity.
>
> “On this flag day we can celebrate Tove Jansson’s profound impact on Finnish art and literature, while also celebrating great Finnish works of art more widely,” says Minister of the Interior Maria Ohisalo.
>
> The Ministry of the Interior has decided that these flag flying arrangements will be observed by government agencies and public bodies on 9 August 2020.

https://valtioneuvosto.fi/en/article/-/asset_publisher/1410869/sunnuntaina-9-8-liputetaan-tove-janssonin-ja-suomalaisen-taiteen-johdosta